### PR TITLE
OpenRC: Set cap_net_bind_service through init script

### DIFF
--- a/contrib/signal-tlsd.initd
+++ b/contrib/signal-tlsd.initd
@@ -2,12 +2,14 @@
 
 name=signal-tlsd
 description="signal-tlsd proxy daemon"
+
 command=/usr/bin/signal-tlsd
 command_args="$signal_tlsd_args"
 command_user="$signal_tlsd_user:$signal_tlsd_group"
+capabilities="^cap_net_bind_service"
+
 command_background=true
 pidfile="/run/$RC_SVCNAME.pid"
-
 error_logger="logger -t '${RC_SVCNAME}' -p daemon.info"
 
 depend() {


### PR DESCRIPTION
This was brought up during review here: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/105260